### PR TITLE
Smaato: Add support for app

### DIFF
--- a/adapters/smaato/smaato.go
+++ b/adapters/smaato/smaato.go
@@ -81,6 +81,7 @@ func (a *SmaatoAdapter) MakeRequests(request *openrtb.BidRequest, reqInfo *adapt
 			i--
 		}
 	}
+
 	if request.Site != nil {
 		siteCopy := *request.Site
 		siteCopy.Publisher = &openrtb.Publisher{ID: publisherID}
@@ -96,6 +97,13 @@ func (a *SmaatoAdapter) MakeRequests(request *openrtb.BidRequest, reqInfo *adapt
 			siteCopy.Ext = nil
 		}
 		request.Site = &siteCopy
+	}
+
+	if request.App != nil {
+		appCopy := *request.App
+		appCopy.Publisher = &openrtb.Publisher{ID: publisherID}
+
+		request.App = &appCopy
 	}
 
 	if request.User != nil && request.User.Ext != nil {

--- a/adapters/smaato/smaato.go
+++ b/adapters/smaato/smaato.go
@@ -14,7 +14,7 @@ import (
 	"github.com/prebid/prebid-server/openrtb_ext"
 )
 
-const clientVersion = "prebid_server_0.1"
+const clientVersion = "prebid_server_0.2"
 
 type adMarkupType string
 

--- a/adapters/smaato/smaatotest/exemplary/simple-banner-app.json
+++ b/adapters/smaato/smaatotest/exemplary/simple-banner-app.json
@@ -160,7 +160,7 @@
             "keywords": "keywords"
           },
           "ext": {
-            "client": "prebid_server_0.1"
+            "client": "prebid_server_0.2"
           }
         }
       },

--- a/adapters/smaato/smaatotest/exemplary/simple-banner-app.json
+++ b/adapters/smaato/smaatotest/exemplary/simple-banner-app.json
@@ -1,0 +1,225 @@
+{
+  "mockBidRequest": {
+    "id": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+    "app": {
+      "id": "app-id",
+      "name": "app-name",
+      "bundle": "app-bundle",
+      "storeurl": "app-storeurl",
+      "cat": [
+        "IAB3-1"
+      ],
+      "ver": "app-version",
+      "paid": 1,
+      "content": {
+        "id": "content-id",
+        "title": "content-title",
+        "series": "content-series",
+        "genre": "content-genre",
+        "producer": {
+          "id": "producer-id",
+          "name": "producer-name"
+        },
+        "cat": [
+              "IAB8-6"
+              ],
+        "livestream": 1,
+        "language": "en"
+      },
+      "keywords": "keywords"
+    },
+    "imp": [
+      {
+        "id": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+        "banner": {
+          "format": [
+            {
+              "w": 320,
+              "h": 50
+            },
+            {
+              "w": 320,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "1100042525",
+            "adspaceId": "130563103"
+          }
+        }
+      }
+    ],
+    "device": {
+      "ua": "test-user-agent",
+      "ip": "123.123.123.123",
+      "language": "en",
+      "dnt": 0
+    },
+    "user": {
+      "ext": {
+        "consent": "gdprConsentString",
+        "data": {
+          "keywords": "a,b",
+          "gender": "M",
+          "yob": 1984,
+          "geo": {
+            "country": "ca"
+          }
+        }
+      }
+    },
+    "regs": {
+      "coppa": 1,
+      "ext": {
+        "gdpr": 1,
+        "us_privacy": "uspConsentString"
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"]
+        },
+        "uri": "https://prebid/bidder",
+        "body": {
+          "id": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+          "imp": [
+            {
+              "id": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+              "tagid": "130563103",
+              "banner": {
+                "h": 50,
+                "w": 320,
+                "format": [
+                  {
+                    "w": 320,
+                    "h": 50
+                  },
+                  {
+                    "w": 320,
+                    "h": 250
+                  }
+                ]
+              }
+            }
+          ],
+          "user": {
+            "ext": {
+              "consent": "gdprConsentString"
+            },
+            "gender": "M",
+            "keywords": "a,b",
+            "yob": 1984
+          },
+          "device": {
+            "ua": "test-user-agent",
+            "ip": "123.123.123.123",
+            "language": "en",
+            "dnt": 0
+          },
+          "regs": {
+            "coppa": 1,
+            "ext": {
+              "gdpr": 1,
+              "us_privacy": "uspConsentString"
+            }
+          },
+          "app": {
+            "publisher": {
+              "id": "1100042525"
+            },
+            "id": "app-id",
+            "name": "app-name",
+            "bundle": "app-bundle",
+            "storeurl": "app-storeurl",
+            "cat": [
+              "IAB3-1"
+            ],
+            "ver": "app-version",
+            "paid": 1,
+            "content": {
+              "id": "content-id",
+              "title": "content-title",
+              "series": "content-series",
+              "genre": "content-genre",
+              "producer": {
+                "id": "producer-id",
+                "name": "producer-name"
+              },
+              "cat": [
+                "IAB8-6"
+              ],
+              "livestream": 1,
+              "language": "en"
+            },
+            "keywords": "keywords"
+          },
+          "ext": {
+            "client": "prebid_server_0.1"
+          }
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "5ebea288-f13a-4754-be6d-4ade66c68877",
+          "seatbid": [
+            {
+              "seat": "CM6523",
+              "bid": [
+                {
+                  "adm": "{\"image\":{\"img\":{\"url\":\"//prebid-test.smaatolabs.net/img/320x50.jpg\",\"w\":350,\"h\":50,\"ctaurl\":\"//prebid-test.smaatolabs.net/track/ctaurl/1\"},\"impressiontrackers\":[\"//prebid-test.smaatolabs.net/track/imp/1\",\"//prebid-test.smaatolabs.net/track/imp/2\"],\"clicktrackers\":[\"//prebid-test.smaatolabs.net/track/click/1\",\"//prebid-test.smaatolabs.net/track/click/2\"]}}",
+                  "adomain": [
+                    "smaato.com"
+                  ],
+                  "bidderName": "smaato",
+                  "cid": "CM6523",
+                  "crid": "CR69381",
+                  "id": "6906aae8-7f74-4edd-9a4f-f49379a3cadd",
+                  "impid": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+                  "iurl": "https://bidstalkcreatives.s3.amazonaws.com/1x1.png",
+                  "nurl": "https://ets-eu-west-1.track.smaato.net/v1/view?sessionId=e4e17adb-9599-42b1-bb5f-a1f1b3bee572&adSourceId=6906aae8-7f74-4edd-9a4f-f49379a3cadd&originalRequestTime=1552310449698&expires=1552311350698&winurl=ama8JbpJVpFWxvEja5viE3cLXFu58qRI8dGUh23xtsOn3N2-5UU0IwkgNEmR82pI37fcMXejL5IWTNAoW6Cnsjf-Dxl_vx2dUqMrVEevX-Vdx2VVnf-D5f73gZhvi4t36iPL8Dsw4aACekoLvVOV7-eXDjz7GHy60QFqcwKf5g2AlKPOInyZ6vJg_fn4qA9argvCRgwVybXE9Ndm2W0v8La4uFYWpJBOUveDDUrSQfzal7RsYvLb_OyaMlPHdrd_bwA9qqZWuyJXd-L9lxr7RQ%3D%3D%7CMw3kt91KJR0Uy5L-oNztAg%3D%3D&dpid=4XVofb_lH-__hr2JNGhKfg%3D%3D%7Cr9ciCU1cx3zmHXihItKO0g%3D%3D",
+                  "price": 0.01,
+                  "w": 350,
+                  "h": 50
+                }
+              ]
+            }
+          ],
+          "bidid": "04db8629-179d-4bcd-acce-e54722969006",
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "adm": "<div style=\"cursor:pointer\" onclick=\"fetch(decodeURIComponent('%2F%2Fprebid-test.smaatolabs.net%2Ftrack%2Fclick%2F1'.replace(/\\+/g, ' ')), {cache: 'no-cache'});fetch(decodeURIComponent('%2F%2Fprebid-test.smaatolabs.net%2Ftrack%2Fclick%2F2'.replace(/\\+/g, ' ')), {cache: 'no-cache'});;window.open(decodeURIComponent('%2F%2Fprebid-test.smaatolabs.net%2Ftrack%2Fctaurl%2F1'.replace(/\\+/g, ' ')));\"><img src=\"//prebid-test.smaatolabs.net/img/320x50.jpg\" width=\"350\" height=\"50\"/><img src=\"//prebid-test.smaatolabs.net/track/imp/1\" alt=\"\" width=\"0\" height=\"0\"/><img src=\"//prebid-test.smaatolabs.net/track/imp/2\" alt=\"\" width=\"0\" height=\"0\"/></div>",
+            "adomain": [
+              "smaato.com"
+            ],
+            "cid": "CM6523",
+            "crid": "CR69381",
+            "id": "6906aae8-7f74-4edd-9a4f-f49379a3cadd",
+            "impid": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+            "iurl": "https://bidstalkcreatives.s3.amazonaws.com/1x1.png",
+            "nurl": "https://ets-eu-west-1.track.smaato.net/v1/view?sessionId=e4e17adb-9599-42b1-bb5f-a1f1b3bee572&adSourceId=6906aae8-7f74-4edd-9a4f-f49379a3cadd&originalRequestTime=1552310449698&expires=1552311350698&winurl=ama8JbpJVpFWxvEja5viE3cLXFu58qRI8dGUh23xtsOn3N2-5UU0IwkgNEmR82pI37fcMXejL5IWTNAoW6Cnsjf-Dxl_vx2dUqMrVEevX-Vdx2VVnf-D5f73gZhvi4t36iPL8Dsw4aACekoLvVOV7-eXDjz7GHy60QFqcwKf5g2AlKPOInyZ6vJg_fn4qA9argvCRgwVybXE9Ndm2W0v8La4uFYWpJBOUveDDUrSQfzal7RsYvLb_OyaMlPHdrd_bwA9qqZWuyJXd-L9lxr7RQ%3D%3D%7CMw3kt91KJR0Uy5L-oNztAg%3D%3D&dpid=4XVofb_lH-__hr2JNGhKfg%3D%3D%7Cr9ciCU1cx3zmHXihItKO0g%3D%3D",
+            "price": 0.01,
+            "w": 350,
+            "h": 50
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/smaato/smaatotest/exemplary/simple-banner-richMedia-app.json
+++ b/adapters/smaato/smaatotest/exemplary/simple-banner-richMedia-app.json
@@ -1,0 +1,229 @@
+{
+  "mockBidRequest": {
+    "id": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+    "app": {
+      "id": "app-id",
+      "name": "app-name",
+      "bundle": "app-bundle",
+      "storeurl": "app-storeurl",
+      "cat": [
+        "IAB3-1"
+      ],
+      "ver": "app-version",
+      "paid": 1,
+      "content": {
+        "id": "content-id",
+        "title": "content-title",
+        "series": "content-series",
+        "genre": "content-genre",
+        "producer": {
+          "id": "producer-id",
+          "name": "producer-name"
+        },
+        "cat": [
+          "IAB8-6"
+        ],
+        "livestream": 1,
+        "language": "en"
+      },
+      "keywords": "keywords"
+    },
+    "imp": [
+      {
+        "id": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+        "banner": {
+          "format": [
+            {
+              "w": 320,
+              "h": 50
+            },
+            {
+              "w": 320,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "1100042525",
+            "adspaceId": "130563103"
+          }
+        }
+      }
+    ],
+    "device": {
+      "ua": "test-user-agent",
+      "ip": "123.123.123.123",
+      "language": "en",
+      "dnt": 0
+    },
+    "user": {
+      "ext": {
+        "consent": "gdprConsentString",
+        "data": {
+          "keywords": "a,b",
+          "gender": "M",
+          "yob": 1984,
+          "geo": {
+            "country": "ca"
+          }
+        }
+      }
+    },
+    "regs": {
+      "coppa": 1,
+      "ext": {
+        "gdpr": 1,
+        "us_privacy": "uspConsentString"
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "headers": {
+          "Content-Type": [
+            "application/json;charset=utf-8"
+          ],
+          "Accept": [
+            "application/json"
+          ]
+        },
+        "uri": "https://prebid/bidder",
+        "body": {
+          "id": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+          "imp": [
+            {
+              "id": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+              "tagid": "130563103",
+              "banner": {
+                "h": 50,
+                "w": 320,
+                "format": [
+                  {
+                    "w": 320,
+                    "h": 50
+                  },
+                  {
+                    "w": 320,
+                    "h": 250
+                  }
+                ]
+              }
+            }
+          ],
+          "user": {
+            "gender": "M",
+            "keywords": "a,b",
+            "yob": 1984,
+            "ext": {
+              "consent": "gdprConsentString"
+            }
+          },
+          "device": {
+            "ua": "test-user-agent",
+            "ip": "123.123.123.123",
+            "language": "en",
+            "dnt": 0
+          },
+          "regs": {
+            "coppa": 1,
+            "ext": {
+              "gdpr": 1,
+              "us_privacy": "uspConsentString"
+            }
+          },
+          "app": {
+            "publisher": {
+              "id": "1100042525"
+            },
+            "id": "app-id",
+            "name": "app-name",
+            "bundle": "app-bundle",
+            "storeurl": "app-storeurl",
+            "cat": [
+              "IAB3-1"
+            ],
+            "ver": "app-version",
+            "paid": 1,
+            "content": {
+              "id": "content-id",
+              "title": "content-title",
+              "series": "content-series",
+              "genre": "content-genre",
+              "producer": {
+                "id": "producer-id",
+                "name": "producer-name"
+              },
+              "cat": [
+                "IAB8-6"
+              ],
+              "livestream": 1,
+              "language": "en"
+            },
+            "keywords": "keywords"
+          },
+          "ext": {
+            "client": "prebid_server_0.1"
+          }
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "5ebea288-f13a-4754-be6d-4ade66c68877",
+          "seatbid": [
+            {
+              "seat": "CM6523",
+              "bid": [
+                {
+                  "adm": "{\"richmedia\":{\"mediadata\":{\"content\":\"<div>hello</div>\", \"w\":350,\"h\":50},\"impressiontrackers\":[\"//prebid-test.smaatolabs.net/track/imp/1\",\"//prebid-test.smaatolabs.net/track/imp/2\"],\"clicktrackers\":[\"//prebid-test.smaatolabs.net/track/click/1\",\"//prebid-test.smaatolabs.net/track/click/2\"]}}",
+                  "adomain": [
+                    "smaato.com"
+                  ],
+                  "bidderName": "smaato",
+                  "cid": "CM6523",
+                  "crid": "CR69381",
+                  "id": "6906aae8-7f74-4edd-9a4f-f49379a3cadd",
+                  "impid": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+                  "iurl": "https://bidstalkcreatives.s3.amazonaws.com/1x1.png",
+                  "nurl": "https://ets-eu-west-1.track.smaato.net/v1/view?sessionId=e4e17adb-9599-42b1-bb5f-a1f1b3bee572&adSourceId=6906aae8-7f74-4edd-9a4f-f49379a3cadd&originalRequestTime=1552310449698&expires=1552311350698&winurl=ama8JbpJVpFWxvEja5viE3cLXFu58qRI8dGUh23xtsOn3N2-5UU0IwkgNEmR82pI37fcMXejL5IWTNAoW6Cnsjf-Dxl_vx2dUqMrVEevX-Vdx2VVnf-D5f73gZhvi4t36iPL8Dsw4aACekoLvVOV7-eXDjz7GHy60QFqcwKf5g2AlKPOInyZ6vJg_fn4qA9argvCRgwVybXE9Ndm2W0v8La4uFYWpJBOUveDDUrSQfzal7RsYvLb_OyaMlPHdrd_bwA9qqZWuyJXd-L9lxr7RQ%3D%3D%7CMw3kt91KJR0Uy5L-oNztAg%3D%3D&dpid=4XVofb_lH-__hr2JNGhKfg%3D%3D%7Cr9ciCU1cx3zmHXihItKO0g%3D%3D",
+                  "price": 0.01,
+                  "w": 350,
+                  "h": 50
+                }
+              ]
+            }
+          ],
+          "bidid": "04db8629-179d-4bcd-acce-e54722969006",
+          "cur": "USD"
+        }
+      }
+    }
+  ],
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": [
+        {
+          "bid": {
+            "adm": "<div onclick=\"fetch(decodeURIComponent('%2F%2Fprebid-test.smaatolabs.net%2Ftrack%2Fclick%2F1'), {cache: 'no-cache'});fetch(decodeURIComponent('%2F%2Fprebid-test.smaatolabs.net%2Ftrack%2Fclick%2F2'), {cache: 'no-cache'});\"><div>hello</div><img src=\"//prebid-test.smaatolabs.net/track/imp/1\" alt=\"\" width=\"0\" height=\"0\"/><img src=\"//prebid-test.smaatolabs.net/track/imp/2\" alt=\"\" width=\"0\" height=\"0\"/></div>",
+            "adomain": [
+              "smaato.com"
+            ],
+            "cid": "CM6523",
+            "crid": "CR69381",
+            "id": "6906aae8-7f74-4edd-9a4f-f49379a3cadd",
+            "impid": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+            "iurl": "https://bidstalkcreatives.s3.amazonaws.com/1x1.png",
+            "nurl": "https://ets-eu-west-1.track.smaato.net/v1/view?sessionId=e4e17adb-9599-42b1-bb5f-a1f1b3bee572&adSourceId=6906aae8-7f74-4edd-9a4f-f49379a3cadd&originalRequestTime=1552310449698&expires=1552311350698&winurl=ama8JbpJVpFWxvEja5viE3cLXFu58qRI8dGUh23xtsOn3N2-5UU0IwkgNEmR82pI37fcMXejL5IWTNAoW6Cnsjf-Dxl_vx2dUqMrVEevX-Vdx2VVnf-D5f73gZhvi4t36iPL8Dsw4aACekoLvVOV7-eXDjz7GHy60QFqcwKf5g2AlKPOInyZ6vJg_fn4qA9argvCRgwVybXE9Ndm2W0v8La4uFYWpJBOUveDDUrSQfzal7RsYvLb_OyaMlPHdrd_bwA9qqZWuyJXd-L9lxr7RQ%3D%3D%7CMw3kt91KJR0Uy5L-oNztAg%3D%3D&dpid=4XVofb_lH-__hr2JNGhKfg%3D%3D%7Cr9ciCU1cx3zmHXihItKO0g%3D%3D",
+            "price": 0.01,
+            "w": 350,
+            "h": 50
+          },
+          "type": "banner"
+        }
+      ]
+    }
+  ]
+}

--- a/adapters/smaato/smaatotest/exemplary/simple-banner-richMedia-app.json
+++ b/adapters/smaato/smaatotest/exemplary/simple-banner-richMedia-app.json
@@ -164,7 +164,7 @@
             "keywords": "keywords"
           },
           "ext": {
-            "client": "prebid_server_0.1"
+            "client": "prebid_server_0.2"
           }
         }
       },

--- a/adapters/smaato/smaatotest/exemplary/simple-banner-richMedia.json
+++ b/adapters/smaato/smaatotest/exemplary/simple-banner-richMedia.json
@@ -129,7 +129,7 @@
             "keywords": "power tools"
           },
           "ext": {
-            "client": "prebid_server_0.1"
+            "client": "prebid_server_0.2"
           }
         }
       },

--- a/adapters/smaato/smaatotest/exemplary/simple-banner.json
+++ b/adapters/smaato/smaatotest/exemplary/simple-banner.json
@@ -125,7 +125,7 @@
             "keywords": "power tools"
           },
           "ext": {
-            "client": "prebid_server_0.1"
+            "client": "prebid_server_0.2"
           }
         }
       },

--- a/adapters/smaato/smaatotest/exemplary/video-app.json
+++ b/adapters/smaato/smaatotest/exemplary/video-app.json
@@ -165,7 +165,7 @@
                         "keywords": "keywords"
                     },
                     "ext": {
-                        "client": "prebid_server_0.1"
+                        "client": "prebid_server_0.2"
                     }
                 }
             },

--- a/adapters/smaato/smaatotest/exemplary/video-app.json
+++ b/adapters/smaato/smaatotest/exemplary/video-app.json
@@ -1,0 +1,230 @@
+{
+    "mockBidRequest": {
+        "id": "447a0a1d-389d-4730-a418-3777e95de7bd",
+        "imp": [
+            {
+                "id": "postbid_iframe",
+                "video": {
+                    "mimes": [
+                        "video/mp4",
+                        "video/quicktime",
+                        "video/3gpp",
+                        "video/x-m4v"
+                    ],
+                    "minduration": 5,
+                    "maxduration": 30,
+                    "protocols": [
+                        7
+                    ],
+                    "w": 1024,
+                    "h": 768,
+                    "startdelay": 0,
+                    "linearity": 1,
+                    "skip": 1,
+                    "skipmin": 5,
+                    "api": [
+                        7
+                    ],
+                    "ext": {
+                        "rewarded": 0
+                    }
+                },
+                "ext": {
+                    "bidder": {
+                        "publisherId": "1100042525",
+                        "adspaceId": "130563103"
+                    }
+                }
+            }
+        ],
+        "app": {
+            "id": "app-id",
+            "name": "app-name",
+            "bundle": "app-bundle",
+            "storeurl": "app-storeurl",
+            "cat": [
+                "IAB3-1"
+            ],
+            "ver": "app-version",
+            "paid": 1,
+            "content": {
+                "id": "content-id",
+                "title": "content-title",
+                "series": "content-series",
+                "genre": "content-genre",
+                "producer": {
+                    "id": "producer-id",
+                    "name": "producer-name"
+                },
+                "cat": [
+                    "IAB8-6"
+                ],
+                "livestream": 1,
+                "language": "en"
+            },
+            "keywords": "keywords"
+        },
+        "device": {
+            "ua": "test-user-agent"
+        },
+        "user": {
+            "ext": {
+                "data": {}
+            }
+        },
+        "ext": {
+            "prebid": {
+                "auctiontimestamp": 1598262728811,
+                "targeting": {
+                    "includewinners": true,
+                    "includebidderkeys": false
+                }
+            }
+        }
+    },
+    "httpCalls": [
+        {
+            "expectedRequest": {
+                "headers": {
+                    "Content-Type": [
+                        "application/json;charset=utf-8"
+                    ],
+                    "Accept": [
+                        "application/json"
+                    ]
+                },
+                "uri": "https://prebid/bidder",
+                "body": {
+                    "id": "447a0a1d-389d-4730-a418-3777e95de7bd",
+                    "imp": [
+                        {
+                            "id": "postbid_iframe",
+                            "tagid": "130563103",
+                            "video": {
+                                "w": 1024,
+                                "h": 768,
+                                "ext": {
+                                    "rewarded": 0
+                                },
+                                "mimes": [
+                                    "video/mp4",
+                                    "video/quicktime",
+                                    "video/3gpp",
+                                    "video/x-m4v"
+                                ],
+                                "minduration": 5,
+                                "startdelay": 0,
+                                "linearity": 1,
+                                "maxduration": 30,
+                                "skip": 1,
+                                "protocols": [
+                                    7
+                                ],
+                                "skipmin": 5,
+                                "api": [
+                                    7
+                                ]
+                            }
+                        }
+                    ],
+                    "user": {
+                        "ext": {
+                        }
+                    },
+                    "device": {
+                        "ua": "test-user-agent"
+                    },
+                    "app": {
+                        "publisher": {
+                            "id": "1100042525"
+                        },
+                        "id": "app-id",
+                        "name": "app-name",
+                        "bundle": "app-bundle",
+                        "storeurl": "app-storeurl",
+                        "cat": [
+                            "IAB3-1"
+                        ],
+                        "ver": "app-version",
+                        "paid": 1,
+                        "content": {
+                            "id": "content-id",
+                            "title": "content-title",
+                            "series": "content-series",
+                            "genre": "content-genre",
+                            "producer": {
+                                "id": "producer-id",
+                                "name": "producer-name"
+                            },
+                            "cat": [
+                                "IAB8-6"
+                            ],
+                            "livestream": 1,
+                            "language": "en"
+                        },
+                        "keywords": "keywords"
+                    },
+                    "ext": {
+                        "client": "prebid_server_0.1"
+                    }
+                }
+            },
+            "mockResponse": {
+                "status": 200,
+                "body": {
+                    "id": "5ebea288-f13a-4754-be6d-4ade66c68877",
+                    "seatbid": [
+                        {
+                            "seat": "CM6523",
+                            "bid": [
+                                {
+                                    "adm": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><VAST version=\"2.0\"></VAST>",
+                                    "adomain": [
+                                        "smaato.com"
+                                    ],
+                                    "bidderName": "smaato",
+                                    "cid": "CM6523",
+                                    "crid": "CR69381",
+                                    "id": "6906aae8-7f74-4edd-9a4f-f49379a3cadd",
+                                    "impid": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+                                    "iurl": "https://iurl",
+                                    "nurl": "https://nurl",
+                                    "price": 0.01,
+                                    "w": 1024,
+                                    "h": 768
+                                }
+                            ]
+                        }
+                    ],
+                    "bidid": "04db8629-179d-4bcd-acce-e54722969006",
+                    "cur": "USD"
+                }
+            }
+        }
+    ],
+    "expectedBidResponses": [
+        {
+            "currency": "USD",
+            "bids": [
+                {
+                    "bid": {
+                        "adm": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><VAST version=\"2.0\"></VAST>",
+                        "adomain": [
+                            "smaato.com"
+                        ],
+                        "cid": "CM6523",
+                        "crid": "CR69381",
+                        "id": "6906aae8-7f74-4edd-9a4f-f49379a3cadd",
+                        "impid": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+                        "iurl": "https://iurl",
+                        "nurl": "https://nurl",
+                        "price": 0.01,
+                        "w": 1024,
+                        "h": 768
+                    },
+                    "type": "video"
+                }
+            ]
+        }
+    ]
+}

--- a/adapters/smaato/smaatotest/exemplary/video.json
+++ b/adapters/smaato/smaatotest/exemplary/video.json
@@ -122,7 +122,7 @@
                         }
                     },
                     "ext": {
-                        "client": "prebid_server_0.1"
+                        "client": "prebid_server_0.2"
                     }
                 }
             },

--- a/adapters/smaato/smaatotest/supplemental/bad-adm-response.json
+++ b/adapters/smaato/smaatotest/supplemental/bad-adm-response.json
@@ -125,7 +125,7 @@
             "keywords": "power tools"
           },
           "ext": {
-            "client": "prebid_server_0.1"
+            "client": "prebid_server_0.2"
           }
         }
       },

--- a/adapters/smaato/smaatotest/supplemental/bad-imp-banner-format-req.json
+++ b/adapters/smaato/smaatotest/supplemental/bad-imp-banner-format-req.json
@@ -40,7 +40,7 @@
             }
           },
           "ext": {
-            "client": "prebid_server_0.1"
+            "client": "prebid_server_0.2"
           }
         }
       }

--- a/adapters/smaato/smaatotest/supplemental/no-consent-info.json
+++ b/adapters/smaato/smaatotest/supplemental/no-consent-info.json
@@ -72,7 +72,7 @@
             }
           },
           "ext": {
-            "client": "prebid_server_0.1"
+            "client": "prebid_server_0.2"
           }
         }
       },

--- a/adapters/smaato/smaatotest/supplemental/status-code-204.json
+++ b/adapters/smaato/smaatotest/supplemental/status-code-204.json
@@ -1,0 +1,139 @@
+{
+  "mockBidRequest": {
+    "id": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+    "site": {
+      "publisher": {
+        "id": "1100042525"
+      },
+      "page": "http://localhost:3000/server.html?pbjs_debug=true&endpoint=http://localhost:3000/bidder",
+      "ext": {
+        "data": {
+          "keywords": "power tools",
+          "search": "drill",
+          "content": {
+            "userrating": 4
+          }
+        }
+      }
+    },
+    "imp": [
+      {
+        "id": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+        "banner": {
+          "format": [
+            {
+              "w": 320,
+              "h": 50
+            },
+            {
+              "w": 320,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "1100042525",
+            "adspaceId": "130563103"
+          }
+        }
+      }
+    ],
+    "device": {
+      "ua": "test-user-agent",
+      "ip": "123.123.123.123",
+      "language": "en",
+      "dnt": 0
+    },
+    "user": {
+      "ext": {
+        "consent": "gdprConsentString",
+        "data": {
+          "keywords": "a,b",
+          "gender": "M",
+          "yob": 1984,
+          "geo": {
+            "country": "ca"
+          }
+        }
+      }
+    },
+    "regs": {
+      "coppa": 1,
+      "ext": {
+        "gdpr": 1,
+        "us_privacy": "uspConsentString"
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"]
+        },
+        "uri": "https://prebid/bidder",
+        "body": {
+          "id": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+          "imp": [
+            {
+              "id": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+              "tagid": "130563103",
+              "banner": {
+                "h": 50,
+                "w": 320,
+                "format": [
+                  {
+                    "w": 320,
+                    "h": 50
+                  },
+                  {
+                    "w": 320,
+                    "h": 250
+                  }
+                ]
+              }
+            }
+          ],
+          "user": {
+            "ext": {
+              "consent": "gdprConsentString"
+            },
+            "gender": "M",
+            "keywords": "a,b",
+            "yob": 1984
+          },
+          "device": {
+            "ua": "test-user-agent",
+            "ip": "123.123.123.123",
+            "language": "en",
+            "dnt": 0
+          },
+          "regs": {
+            "coppa": 1,
+            "ext": {
+              "gdpr": 1,
+              "us_privacy": "uspConsentString"
+            }
+          },
+          "site": {
+            "publisher": {
+              "id": "1100042525"
+            },
+            "page": "http://localhost:3000/server.html?pbjs_debug=true&endpoint=http://localhost:3000/bidder",
+            "keywords": "power tools"
+          },
+          "ext": {
+            "client": "prebid_server_0.2"
+          }
+        }
+      },
+      "mockResponse": {
+        "status": 204
+      }
+    }
+  ],
+  "expectedBidResponses": [],
+  "expectedMakeBidsErrors": []
+}

--- a/adapters/smaato/smaatotest/supplemental/status-code-400.json
+++ b/adapters/smaato/smaatotest/supplemental/status-code-400.json
@@ -1,0 +1,144 @@
+{
+  "mockBidRequest": {
+    "id": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+    "site": {
+      "publisher": {
+        "id": "1100042525"
+      },
+      "page": "http://localhost:3000/server.html?pbjs_debug=true&endpoint=http://localhost:3000/bidder",
+      "ext": {
+        "data": {
+          "keywords": "power tools",
+          "search": "drill",
+          "content": {
+            "userrating": 4
+          }
+        }
+      }
+    },
+    "imp": [
+      {
+        "id": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+        "banner": {
+          "format": [
+            {
+              "w": 320,
+              "h": 50
+            },
+            {
+              "w": 320,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "1100042525",
+            "adspaceId": "130563103"
+          }
+        }
+      }
+    ],
+    "device": {
+      "ua": "test-user-agent",
+      "ip": "123.123.123.123",
+      "language": "en",
+      "dnt": 0
+    },
+    "user": {
+      "ext": {
+        "consent": "gdprConsentString",
+        "data": {
+          "keywords": "a,b",
+          "gender": "M",
+          "yob": 1984,
+          "geo": {
+            "country": "ca"
+          }
+        }
+      }
+    },
+    "regs": {
+      "coppa": 1,
+      "ext": {
+        "gdpr": 1,
+        "us_privacy": "uspConsentString"
+      }
+    }
+  },
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "headers": {
+          "Content-Type": ["application/json;charset=utf-8"],
+          "Accept": ["application/json"]
+        },
+        "uri": "https://prebid/bidder",
+        "body": {
+          "id": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+          "imp": [
+            {
+              "id": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+              "tagid": "130563103",
+              "banner": {
+                "h": 50,
+                "w": 320,
+                "format": [
+                  {
+                    "w": 320,
+                    "h": 50
+                  },
+                  {
+                    "w": 320,
+                    "h": 250
+                  }
+                ]
+              }
+            }
+          ],
+          "user": {
+            "ext": {
+              "consent": "gdprConsentString"
+            },
+            "gender": "M",
+            "keywords": "a,b",
+            "yob": 1984
+          },
+          "device": {
+            "ua": "test-user-agent",
+            "ip": "123.123.123.123",
+            "language": "en",
+            "dnt": 0
+          },
+          "regs": {
+            "coppa": 1,
+            "ext": {
+              "gdpr": 1,
+              "us_privacy": "uspConsentString"
+            }
+          },
+          "site": {
+            "publisher": {
+              "id": "1100042525"
+            },
+            "page": "http://localhost:3000/server.html?pbjs_debug=true&endpoint=http://localhost:3000/bidder",
+            "keywords": "power tools"
+          },
+          "ext": {
+            "client": "prebid_server_0.2"
+          }
+        }
+      },
+      "mockResponse": {
+        "status": 400
+      }
+    }
+  ],
+  "expectedBidResponses": [],
+  "expectedMakeBidsErrors": [
+    {
+      "value": "Unexpected status code: 400. Run with request.debug = 1 for more info",
+      "comparison": "literal"
+    }
+  ]
+}


### PR DESCRIPTION
This PR allows the Smaato adapter to send app bid requests to the Smaato bidder endpoint.