### PR TITLE
PREB-39 added support for imp.ext and added imp.ext.skadn to it

### DIFF
--- a/adapters/smaato/smaato.go
+++ b/adapters/smaato/smaato.go
@@ -17,7 +17,7 @@ import (
 	"github.com/prebid/prebid-server/util/timeutil"
 )
 
-const clientVersion = "prebid_server_0.5"
+const clientVersion = "prebid_server_0.6"
 
 type adMarkupType string
 
@@ -32,6 +32,11 @@ const (
 type adapter struct {
 	clock    timeutil.Time
 	endpoint string
+}
+
+// impExt defines Imp.Ext object for Smaato
+type impExtData struct {
+	Skadn json.RawMessage `json:"skadn,omitempty"`
 }
 
 // userExtData defines User.Ext.Data object for Smaato
@@ -464,6 +469,11 @@ func setImpForAdspace(imp *openrtb2.Imp) error {
 		return &errortypes.BadInput{Message: "Missing adspaceId parameter."}
 	}
 
+	impExt, err := makeImpExt(&imp.Ext)
+	if err != nil {
+		return err
+	}
+
 	if imp.Banner != nil {
 		bannerCopy, err := setBannerDimension(imp.Banner)
 		if err != nil {
@@ -471,13 +481,13 @@ func setImpForAdspace(imp *openrtb2.Imp) error {
 		}
 		imp.Banner = bannerCopy
 		imp.TagID = adSpaceID
-		imp.Ext = nil
+		imp.Ext = impExt
 		return nil
 	}
 
 	if imp.Video != nil || imp.Native != nil {
 		imp.TagID = adSpaceID
-		imp.Ext = nil
+		imp.Ext = impExt
 		return nil
 	}
 
@@ -494,6 +504,11 @@ func setImpForAdBreak(imps []openrtb2.Imp) error {
 		return &errortypes.BadInput{Message: "Missing adbreakId parameter."}
 	}
 
+	impExt, err := makeImpExt(&imps[0].Ext)
+	if err != nil {
+		return err
+	}
+
 	for i := range imps {
 		imps[i].TagID = adBreakID
 		imps[i].Ext = nil
@@ -506,7 +521,31 @@ func setImpForAdBreak(imps []openrtb2.Imp) error {
 		imps[i].Video = &videoCopy
 	}
 
+	imps[0].Ext = impExt
+
 	return nil
+}
+
+func makeImpExt(impExtRaw *json.RawMessage) (json.RawMessage, error) {
+	var impExt impExtData
+
+	if err := json.Unmarshal(*impExtRaw, &impExt); err != nil {
+		return nil, &errortypes.BadInput{Message: "Invalid imp.ext."}
+	}
+
+	if impExtSkadnRaw := impExt.Skadn; impExtSkadnRaw != nil {
+		var impExtSkadn map[string]json.RawMessage
+
+		if err := json.Unmarshal(impExtSkadnRaw, &impExtSkadn); err != nil {
+			return nil, &errortypes.BadInput{Message: "Invalid imp.ext.skadn."}
+		}
+	}
+
+	if impExtJson, err := json.Marshal(impExt); string(impExtJson) != "{}" {
+		return impExtJson, err
+	} else {
+		return nil, nil
+	}
 }
 
 func setBannerDimension(banner *openrtb2.Banner) (*openrtb2.Banner, error) {

--- a/adapters/smaato/smaatotest/exemplary/multiple-impressions-skadn.json
+++ b/adapters/smaato/smaatotest/exemplary/multiple-impressions-skadn.json
@@ -36,6 +36,19 @@
           "bidder": {
             "publisherId": "1100042525",
             "adspaceId": "130563103"
+          },
+          "skadn": {
+            "versions": ["2.0", "2.1", "2.2", "3.0", "4.0"],
+            "sourceapp": "880047117",
+            "productpage": 1,
+            "skadnetlist": {
+              "max": 306,
+              "excl": [2, 8, 10, 55],
+              "addl": [
+                "cdkw7geqsh.skadnetwork",
+                "qyJfv329m4.skadnetwork"
+              ]
+            }
           }
         }
       },
@@ -71,6 +84,19 @@
           "bidder": {
             "publisherId": "1100042526",
             "adspaceId": "130563104"
+          },
+          "skadn": {
+            "versions": ["2.0", "2.1", "2.2", "3.0", "4.0"],
+            "sourceapp": "880047118",
+            "productpage": 1,
+            "skadnetlist": {
+              "max": 306,
+              "excl": [2, 8, 10, 55],
+              "addl": [
+                "cdkw7geqsh.skadnetwork",
+                "qyJfv329m4.skadnetwork"
+              ]
+            }
           }
         }
       }
@@ -130,6 +156,21 @@
                     "h": 250
                   }
                 ]
+              },
+              "ext": {
+                "skadn": {
+                  "versions": ["2.0", "2.1", "2.2", "3.0", "4.0"],
+                  "sourceapp": "880047117",
+                  "productpage": 1,
+                  "skadnetlist": {
+                    "max": 306,
+                    "excl": [2, 8, 10, 55],
+                    "addl": [
+                      "cdkw7geqsh.skadnetwork",
+                      "qyJfv329m4.skadnetwork"
+                    ]
+                  }
+                }
               }
             }
           ],
@@ -188,7 +229,31 @@
                   "nurl": "https://ets-eu-west-1.track.smaato.net/v1/view?sessionId=e4e17adb-9599-42b1-bb5f-a1f1b3bee572&adSourceId=6906aae8-7f74-4edd-9a4f-f49379a3cadd&originalRequestTime=1552310449698&expires=1552311350698&winurl=ama8JbpJVpFWxvEja5viE3cLXFu58qRI8dGUh23xtsOn3N2-5UU0IwkgNEmR82pI37fcMXejL5IWTNAoW6Cnsjf-Dxl_vx2dUqMrVEevX-Vdx2VVnf-D5f73gZhvi4t36iPL8Dsw4aACekoLvVOV7-eXDjz7GHy60QFqcwKf5g2AlKPOInyZ6vJg_fn4qA9argvCRgwVybXE9Ndm2W0v8La4uFYWpJBOUveDDUrSQfzal7RsYvLb_OyaMlPHdrd_bwA9qqZWuyJXd-L9lxr7RQ%3D%3D%7CMw3kt91KJR0Uy5L-oNztAg%3D%3D&dpid=4XVofb_lH-__hr2JNGhKfg%3D%3D%7Cr9ciCU1cx3zmHXihItKO0g%3D%3D",
                   "price": 0.01,
                   "w": 350,
-                  "h": 50
+                  "h": 50,
+                  "ext": {
+                    "skadn": {
+                      "version": "2.2",
+                      "network": "cdkw7geqsh.skadnetwork",
+                      "campaign": "45",
+                      "itunesitem": "123456789",
+                      "sourceapp": "880047117",
+                      "productpageid": "45812c9b-c296-43d3-c6a0-c5a02f74bf6e",
+                      "fidelities": [
+                        {
+                          "fidelity": 0,
+                          "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
+                          "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
+                          "timestamp": "1594406341"
+                        },
+                        {
+                          "fidelity": 1,
+                          "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
+                          "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
+                          "timestamp": "1594406342"
+                        }
+                      ]
+                    }
+                  }
                 }
               ]
             }
@@ -236,6 +301,21 @@
                 "api": [
                   7
                 ]
+              },
+              "ext": {
+                "skadn": {
+                  "versions": ["2.0", "2.1", "2.2", "3.0", "4.0"],
+                  "sourceapp": "880047118",
+                  "productpage": 1,
+                  "skadnetlist": {
+                    "max": 306,
+                    "excl": [2, 8, 10, 55],
+                    "addl": [
+                      "cdkw7geqsh.skadnetwork",
+                      "qyJfv329m4.skadnetwork"
+                    ]
+                  }
+                }
               }
             }
           ],
@@ -294,7 +374,31 @@
                   "nurl": "https://nurl",
                   "price": 0.01,
                   "w": 1024,
-                  "h": 768
+                  "h": 768,
+                  "ext": {
+                    "skadn": {
+                      "version": "2.2",
+                      "network": "cdkw7geqsh.skadnetwork",
+                      "campaign": "45",
+                      "itunesitem": "123456789",
+                      "sourceapp": "880047118",
+                      "productpageid": "45812c9b-c296-43d3-c6a0-c5a02f74bf6e",
+                      "fidelities": [
+                        {
+                          "fidelity": 0,
+                          "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
+                          "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
+                          "timestamp": "1594406341"
+                        },
+                        {
+                          "fidelity": 1,
+                          "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
+                          "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
+                          "timestamp": "1594406342"
+                        }
+                      ]
+                    }
+                  }
                 }
               ]
             }
@@ -324,7 +428,31 @@
             "price": 0.01,
             "w": 350,
             "h": 50,
-            "exp": 300
+            "exp": 300,
+            "ext": {
+              "skadn": {
+                "version": "2.2",
+                "network": "cdkw7geqsh.skadnetwork",
+                "campaign": "45",
+                "itunesitem": "123456789",
+                "sourceapp": "880047117",
+                "productpageid": "45812c9b-c296-43d3-c6a0-c5a02f74bf6e",
+                "fidelities": [
+                  {
+                    "fidelity": 0,
+                    "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
+                    "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
+                    "timestamp": "1594406341"
+                  },
+                  {
+                    "fidelity": 1,
+                    "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
+                    "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
+                    "timestamp": "1594406342"
+                  }
+                ]
+              }
+            }
           },
           "type": "banner"
         }
@@ -348,7 +476,31 @@
             "price": 0.01,
             "w": 1024,
             "h": 768,
-            "exp": 300
+            "exp": 300,
+            "ext": {
+              "skadn": {
+                "version": "2.2",
+                "network": "cdkw7geqsh.skadnetwork",
+                "campaign": "45",
+                "itunesitem": "123456789",
+                "sourceapp": "880047118",
+                "productpageid": "45812c9b-c296-43d3-c6a0-c5a02f74bf6e",
+                "fidelities": [
+                  {
+                    "fidelity": 0,
+                    "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
+                    "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
+                    "timestamp": "1594406341"
+                  },
+                  {
+                    "fidelity": 1,
+                    "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
+                    "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
+                    "timestamp": "1594406342"
+                  }
+                ]
+              }
+            }
           },
           "type": "video"
         }

--- a/adapters/smaato/smaatotest/exemplary/multiple-media-types-skadn.json
+++ b/adapters/smaato/smaatotest/exemplary/multiple-media-types-skadn.json
@@ -31,16 +31,6 @@
             }
           ]
         },
-        "bidfloor": 0.00123,
-        "ext": {
-          "bidder": {
-            "publisherId": "1100042525",
-            "adspaceId": "130563103"
-          }
-        }
-      },
-      {
-        "id": "postbid_iframe",
         "video": {
           "mimes": [
             "video/mp4",
@@ -66,11 +56,24 @@
             "rewarded": 0
           }
         },
-        "bidfloor": 0.00456,
+        "bidfloor": 0.00123,
         "ext": {
           "bidder": {
-            "publisherId": "1100042526",
-            "adspaceId": "130563104"
+            "publisherId": "1100042525",
+            "adspaceId": "130563103"
+          },
+          "skadn": {
+            "versions": ["2.0", "2.1", "2.2", "3.0", "4.0"],
+            "sourceapp": "880047117",
+            "productpage": 1,
+            "skadnetlist": {
+              "max": 306,
+              "excl": [2, 8, 10, 55],
+              "addl": [
+                "cdkw7geqsh.skadnetwork",
+                "qyJfv329m4.skadnetwork"
+              ]
+            }
           }
         }
       }
@@ -130,6 +133,21 @@
                     "h": 250
                   }
                 ]
+              },
+              "ext": {
+                "skadn": {
+                  "versions": ["2.0", "2.1", "2.2", "3.0", "4.0"],
+                  "sourceapp": "880047117",
+                  "productpage": 1,
+                  "skadnetlist": {
+                    "max": 306,
+                    "excl": [2, 8, 10, 55],
+                    "addl": [
+                      "cdkw7geqsh.skadnetwork",
+                      "qyJfv329m4.skadnetwork"
+                    ]
+                  }
+                }
               }
             }
           ],
@@ -188,7 +206,31 @@
                   "nurl": "https://ets-eu-west-1.track.smaato.net/v1/view?sessionId=e4e17adb-9599-42b1-bb5f-a1f1b3bee572&adSourceId=6906aae8-7f74-4edd-9a4f-f49379a3cadd&originalRequestTime=1552310449698&expires=1552311350698&winurl=ama8JbpJVpFWxvEja5viE3cLXFu58qRI8dGUh23xtsOn3N2-5UU0IwkgNEmR82pI37fcMXejL5IWTNAoW6Cnsjf-Dxl_vx2dUqMrVEevX-Vdx2VVnf-D5f73gZhvi4t36iPL8Dsw4aACekoLvVOV7-eXDjz7GHy60QFqcwKf5g2AlKPOInyZ6vJg_fn4qA9argvCRgwVybXE9Ndm2W0v8La4uFYWpJBOUveDDUrSQfzal7RsYvLb_OyaMlPHdrd_bwA9qqZWuyJXd-L9lxr7RQ%3D%3D%7CMw3kt91KJR0Uy5L-oNztAg%3D%3D&dpid=4XVofb_lH-__hr2JNGhKfg%3D%3D%7Cr9ciCU1cx3zmHXihItKO0g%3D%3D",
                   "price": 0.01,
                   "w": 350,
-                  "h": 50
+                  "h": 50,
+                  "ext": {
+                    "skadn": {
+                      "version": "2.2",
+                      "network": "cdkw7geqsh.skadnetwork",
+                      "campaign": "45",
+                      "itunesitem": "123456789",
+                      "sourceapp": "880047117",
+                      "productpageid": "45812c9b-c296-43d3-c6a0-c5a02f74bf6e",
+                      "fidelities": [
+                        {
+                          "fidelity": 0,
+                          "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
+                          "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
+                          "timestamp": "1594406341"
+                        },
+                        {
+                          "fidelity": 1,
+                          "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
+                          "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
+                          "timestamp": "1594406342"
+                        }
+                      ]
+                    }
+                  }
                 }
               ]
             }
@@ -209,9 +251,9 @@
           "id": "1C86242D-9535-47D6-9576-7B1FE87F282C",
           "imp": [
             {
-              "id": "postbid_iframe",
-              "tagid": "130563104",
-              "bidfloor": 0.00456,
+              "id": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+              "tagid": "130563103",
+              "bidfloor": 0.00123,
               "video": {
                 "w": 1024,
                 "h": 768,
@@ -236,6 +278,21 @@
                 "api": [
                   7
                 ]
+              },
+              "ext": {
+                "skadn": {
+                  "versions": ["2.0", "2.1", "2.2", "3.0", "4.0"],
+                  "sourceapp": "880047117",
+                  "productpage": 1,
+                  "skadnetlist": {
+                    "max": 306,
+                    "excl": [2, 8, 10, 55],
+                    "addl": [
+                      "cdkw7geqsh.skadnetwork",
+                      "qyJfv329m4.skadnetwork"
+                    ]
+                  }
+                }
               }
             }
           ],
@@ -262,7 +319,7 @@
           },
           "site": {
             "publisher": {
-              "id": "1100042526"
+              "id": "1100042525"
             },
             "page": "http://localhost:3000/server.html?pbjs_debug=true&endpoint=http://localhost:3000/bidder",
             "keywords": "power tools"
@@ -286,15 +343,39 @@
                     "smaato.com"
                   ],
                   "bidderName": "smaato",
-                  "cid": "CM6524",
-                  "crid": "CR69382",
+                  "cid": "CM6523",
+                  "crid": "CR69381",
                   "id": "6906aae8-7f74-4edd-9a4f-f49379a3cadd",
-                  "impid": "postbid_iframe",
+                  "impid": "1C86242D-9535-47D6-9576-7B1FE87F282C",
                   "iurl": "https://iurl",
                   "nurl": "https://nurl",
                   "price": 0.01,
                   "w": 1024,
-                  "h": 768
+                  "h": 768,
+                  "ext": {
+                    "skadn": {
+                      "version": "2.2",
+                      "network": "qyJfv329m4.skadnetwork",
+                      "campaign": "45",
+                      "itunesitem": "123456789",
+                      "sourceapp": "880047117",
+                      "productpageid": "45812c9b-c296-43d3-c6a0-c5a02f74bf6e",
+                      "fidelities": [
+                        {
+                          "fidelity": 0,
+                          "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
+                          "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
+                          "timestamp": "1594406341"
+                        },
+                        {
+                          "fidelity": 1,
+                          "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
+                          "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
+                          "timestamp": "1594406342"
+                        }
+                      ]
+                    }
+                  }
                 }
               ]
             }
@@ -324,7 +405,31 @@
             "price": 0.01,
             "w": 350,
             "h": 50,
-            "exp": 300
+            "exp": 300,
+            "ext": {
+              "skadn": {
+                "version": "2.2",
+                "network": "cdkw7geqsh.skadnetwork",
+                "campaign": "45",
+                "itunesitem": "123456789",
+                "sourceapp": "880047117",
+                "productpageid": "45812c9b-c296-43d3-c6a0-c5a02f74bf6e",
+                "fidelities": [
+                  {
+                    "fidelity": 0,
+                    "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
+                    "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
+                    "timestamp": "1594406341"
+                  },
+                  {
+                    "fidelity": 1,
+                    "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
+                    "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
+                    "timestamp": "1594406342"
+                  }
+                ]
+              }
+            }
           },
           "type": "banner"
         }
@@ -339,16 +444,40 @@
             "adomain": [
               "smaato.com"
             ],
-            "cid": "CM6524",
-            "crid": "CR69382",
+            "cid": "CM6523",
+            "crid": "CR69381",
             "id": "6906aae8-7f74-4edd-9a4f-f49379a3cadd",
-            "impid": "postbid_iframe",
+            "impid": "1C86242D-9535-47D6-9576-7B1FE87F282C",
             "iurl": "https://iurl",
             "nurl": "https://nurl",
             "price": 0.01,
             "w": 1024,
             "h": 768,
-            "exp": 300
+            "exp": 300,
+            "ext": {
+              "skadn": {
+                "version": "2.2",
+                "network": "qyJfv329m4.skadnetwork",
+                "campaign": "45",
+                "itunesitem": "123456789",
+                "sourceapp": "880047117",
+                "productpageid": "45812c9b-c296-43d3-c6a0-c5a02f74bf6e",
+                "fidelities": [
+                  {
+                    "fidelity": 0,
+                    "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
+                    "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
+                    "timestamp": "1594406341"
+                  },
+                  {
+                    "fidelity": 1,
+                    "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
+                    "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
+                    "timestamp": "1594406342"
+                  }
+                ]
+              }
+            }
           },
           "type": "video"
         }

--- a/adapters/smaato/smaatotest/exemplary/multiple-media-types.json
+++ b/adapters/smaato/smaatotest/exemplary/multiple-media-types.json
@@ -152,7 +152,7 @@
             "keywords": "power tools"
           },
           "ext": {
-            "client": "prebid_server_0.5"
+            "client": "prebid_server_0.6"
           }
         }
       },
@@ -258,7 +258,7 @@
             "keywords": "power tools"
           },
           "ext": {
-            "client": "prebid_server_0.5"
+            "client": "prebid_server_0.6"
           }
         }
       },

--- a/adapters/smaato/smaatotest/exemplary/native.json
+++ b/adapters/smaato/smaatotest/exemplary/native.json
@@ -102,7 +102,7 @@
                         }
                     },
                     "ext": {
-                        "client": "prebid_server_0.5"
+                        "client": "prebid_server_0.6"
                     }
                 }
             },

--- a/adapters/smaato/smaatotest/exemplary/simple-banner-app.json
+++ b/adapters/smaato/smaatotest/exemplary/simple-banner-app.json
@@ -160,7 +160,7 @@
             "keywords": "keywords"
           },
           "ext": {
-            "client": "prebid_server_0.5"
+            "client": "prebid_server_0.6"
           }
         }
       },

--- a/adapters/smaato/smaatotest/exemplary/simple-banner-richMedia-app.json
+++ b/adapters/smaato/smaatotest/exemplary/simple-banner-richMedia-app.json
@@ -164,7 +164,7 @@
             "keywords": "keywords"
           },
           "ext": {
-            "client": "prebid_server_0.5"
+            "client": "prebid_server_0.6"
           }
         }
       },

--- a/adapters/smaato/smaatotest/exemplary/simple-banner-richMedia.json
+++ b/adapters/smaato/smaatotest/exemplary/simple-banner-richMedia.json
@@ -129,7 +129,7 @@
             "keywords": "power tools"
           },
           "ext": {
-            "client": "prebid_server_0.5"
+            "client": "prebid_server_0.6"
           }
         }
       },

--- a/adapters/smaato/smaatotest/exemplary/simple-banner-skadn.json
+++ b/adapters/smaato/smaatotest/exemplary/simple-banner-skadn.json
@@ -37,6 +37,19 @@
           "bidder": {
             "publisherId": "1100042525",
             "adspaceId": "130563103"
+          },
+          "skadn": {
+            "versions": ["2.0", "2.1", "2.2", "3.0", "4.0"],
+            "sourceapp": "880047117",
+            "productpage": 1,
+            "skadnetlist": {
+              "max": 306,
+              "excl": [2, 8, 10, 55],
+              "addl": [
+                "cdkw7geqsh.skadnetwork",
+                "qyJfv329m4.skadnetwork"
+              ]
+            }
           }
         }
       }
@@ -66,7 +79,9 @@
         "gdpr": 1,
         "us_privacy": "uspConsentString",
         "gpp": "gppString",
-        "gpp_sid": [7]
+        "gpp_sid": [
+          7
+        ]
       }
     }
   },
@@ -74,8 +89,12 @@
     {
       "expectedRequest": {
         "headers": {
-          "Content-Type": ["application/json;charset=utf-8"],
-          "Accept": ["application/json"]
+          "Content-Type": [
+            "application/json;charset=utf-8"
+          ],
+          "Accept": [
+            "application/json"
+          ]
         },
         "uri": "https://prebid/bidder",
         "body": {
@@ -99,6 +118,21 @@
                     "h": 250
                   }
                 ]
+              },
+              "ext": {
+                "skadn": {
+                  "versions": ["2.0", "2.1", "2.2", "3.0", "4.0"],
+                  "sourceapp": "880047117",
+                  "productpage": 1,
+                  "skadnetlist": {
+                    "max": 306,
+                    "excl": [2, 8, 10, 55],
+                    "addl": [
+                      "cdkw7geqsh.skadnetwork",
+                      "qyJfv329m4.skadnetwork"
+                    ]
+                  }
+                }
               }
             }
           ],
@@ -122,7 +156,9 @@
               "gdpr": 1,
               "us_privacy": "uspConsentString",
               "gpp": "gppString",
-              "gpp_sid": [7]
+              "gpp_sid": [
+                7
+              ]
             }
           },
           "site": {
@@ -159,7 +195,31 @@
                   "nurl": "https://ets-eu-west-1.track.smaato.net/v1/view?sessionId=e4e17adb-9599-42b1-bb5f-a1f1b3bee572&adSourceId=6906aae8-7f74-4edd-9a4f-f49379a3cadd&originalRequestTime=1552310449698&expires=1552311350698&winurl=ama8JbpJVpFWxvEja5viE3cLXFu58qRI8dGUh23xtsOn3N2-5UU0IwkgNEmR82pI37fcMXejL5IWTNAoW6Cnsjf-Dxl_vx2dUqMrVEevX-Vdx2VVnf-D5f73gZhvi4t36iPL8Dsw4aACekoLvVOV7-eXDjz7GHy60QFqcwKf5g2AlKPOInyZ6vJg_fn4qA9argvCRgwVybXE9Ndm2W0v8La4uFYWpJBOUveDDUrSQfzal7RsYvLb_OyaMlPHdrd_bwA9qqZWuyJXd-L9lxr7RQ%3D%3D%7CMw3kt91KJR0Uy5L-oNztAg%3D%3D&dpid=4XVofb_lH-__hr2JNGhKfg%3D%3D%7Cr9ciCU1cx3zmHXihItKO0g%3D%3D",
                   "price": 0.01,
                   "w": 350,
-                  "h": 50
+                  "h": 50,
+                  "ext": {
+                    "skadn": {
+                      "version": "2.2",
+                      "network": "cdkw7geqsh.skadnetwork",
+                      "campaign": "45",
+                      "itunesitem": "123456789",
+                      "sourceapp": "880047117",
+                      "productpageid": "45812c9b-c296-43d3-c6a0-c5a02f74bf6e",
+                      "fidelities": [
+                        {
+                          "fidelity": 0,
+                          "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
+                          "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
+                          "timestamp": "1594406341"
+                        },
+                        {
+                          "fidelity": 1,
+                          "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
+                          "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
+                          "timestamp": "1594406342"
+                        }
+                      ]
+                    }
+                  }
                 }
               ]
             }
@@ -189,7 +249,31 @@
             "price": 0.01,
             "w": 350,
             "h": 50,
-            "exp": 300
+            "exp": 300,
+            "ext": {
+              "skadn": {
+                "version": "2.2",
+                "network": "cdkw7geqsh.skadnetwork",
+                "campaign": "45",
+                "itunesitem": "123456789",
+                "sourceapp": "880047117",
+                "productpageid": "45812c9b-c296-43d3-c6a0-c5a02f74bf6e",
+                "fidelities": [
+                  {
+                    "fidelity": 0,
+                    "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
+                    "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
+                    "timestamp": "1594406341"
+                  },
+                  {
+                    "fidelity": 1,
+                    "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
+                    "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
+                    "timestamp": "1594406342"
+                  }
+                ]
+              }
+            }
           },
           "type": "banner"
         }

--- a/adapters/smaato/smaatotest/exemplary/video-app.json
+++ b/adapters/smaato/smaatotest/exemplary/video-app.json
@@ -165,7 +165,7 @@
                         "keywords": "keywords"
                     },
                     "ext": {
-                        "client": "prebid_server_0.5"
+                        "client": "prebid_server_0.6"
                     }
                 }
             },

--- a/adapters/smaato/smaatotest/exemplary/video.json
+++ b/adapters/smaato/smaatotest/exemplary/video.json
@@ -144,7 +144,7 @@
                         }
                     },
                     "ext": {
-                        "client": "prebid_server_0.5"
+                        "client": "prebid_server_0.6"
                     }
                 }
             },

--- a/adapters/smaato/smaatotest/supplemental/adtype-header-response.json
+++ b/adapters/smaato/smaatotest/supplemental/adtype-header-response.json
@@ -125,7 +125,7 @@
             "keywords": "power tools"
           },
           "ext": {
-            "client": "prebid_server_0.5"
+            "client": "prebid_server_0.6"
           }
         }
       },

--- a/adapters/smaato/smaatotest/supplemental/bad-adm-response.json
+++ b/adapters/smaato/smaatotest/supplemental/bad-adm-response.json
@@ -125,7 +125,7 @@
             "keywords": "power tools"
           },
           "ext": {
-            "client": "prebid_server_0.5"
+            "client": "prebid_server_0.6"
           }
         }
       },

--- a/adapters/smaato/smaatotest/supplemental/bad-adtype-header-response.json
+++ b/adapters/smaato/smaatotest/supplemental/bad-adtype-header-response.json
@@ -125,7 +125,7 @@
             "keywords": "power tools"
           },
           "ext": {
-            "client": "prebid_server_0.5"
+            "client": "prebid_server_0.6"
           }
         }
       },

--- a/adapters/smaato/smaatotest/supplemental/bad-expires-header-response.json
+++ b/adapters/smaato/smaatotest/supplemental/bad-expires-header-response.json
@@ -125,7 +125,7 @@
             "keywords": "power tools"
           },
           "ext": {
-            "client": "prebid_server_0.5"
+            "client": "prebid_server_0.6"
           }
         }
       },

--- a/adapters/smaato/smaatotest/supplemental/bad-skadn-format-request.json
+++ b/adapters/smaato/smaatotest/supplemental/bad-skadn-format-request.json
@@ -1,0 +1,59 @@
+{
+  "mockBidRequest": {
+    "id": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+    "site": {
+      "publisher": {
+        "id": "1100042525"
+      },
+      "page": "http://localhost:3000/server.html?pbjs_debug=true&endpoint=http://localhost:3000/bidder"
+    },
+    "imp": [
+      {
+        "id": "1C86242D-9535-47D6-9576-7B1FE87F282C",
+        "banner": {
+          "format": [
+            {
+              "w": 320,
+              "h": 50
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "1100042525",
+            "adspaceId": "130563103"
+          },
+          "skadn": []
+        }
+      },
+      {
+        "id": "1C86242D-9535-47D6-9576-7B1FE87F282D",
+        "banner": {
+          "format": [
+            {
+              "w": 320,
+              "h": 50
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "publisherId": "1100042525",
+            "adspaceId": "130563103"
+          },
+          "skadn": ""
+        }
+      }
+    ]
+  },
+  "expectedMakeRequestsErrors": [
+    {
+      "value": "Invalid imp.ext.skadn.",
+      "comparison": "literal"
+    },
+    {
+      "value": "Invalid imp.ext.skadn.",
+      "comparison": "literal"
+    }
+  ]
+}

--- a/adapters/smaato/smaatotest/supplemental/bad-status-code-response.json
+++ b/adapters/smaato/smaatotest/supplemental/bad-status-code-response.json
@@ -125,7 +125,7 @@
             "keywords": "power tools"
           },
           "ext": {
-            "client": "prebid_server_0.5"
+            "client": "prebid_server_0.6"
           }
         }
       },

--- a/adapters/smaato/smaatotest/supplemental/banner-w-and-h.json
+++ b/adapters/smaato/smaatotest/supplemental/banner-w-and-h.json
@@ -107,7 +107,7 @@
             "keywords": "power tools"
           },
           "ext": {
-            "client": "prebid_server_0.5"
+            "client": "prebid_server_0.6"
           }
         }
       },

--- a/adapters/smaato/smaatotest/supplemental/expires-header-response.json
+++ b/adapters/smaato/smaatotest/supplemental/expires-header-response.json
@@ -125,7 +125,7 @@
             "keywords": "power tools"
           },
           "ext": {
-            "client": "prebid_server_0.5"
+            "client": "prebid_server_0.6"
           }
         }
       },

--- a/adapters/smaato/smaatotest/supplemental/no-bid-response.json
+++ b/adapters/smaato/smaatotest/supplemental/no-bid-response.json
@@ -125,7 +125,7 @@
             "keywords": "power tools"
           },
           "ext": {
-            "client": "prebid_server_0.5"
+            "client": "prebid_server_0.6"
           }
         }
       },

--- a/adapters/smaato/smaatotest/supplemental/no-consent-info-request.json
+++ b/adapters/smaato/smaatotest/supplemental/no-consent-info-request.json
@@ -72,7 +72,7 @@
             }
           },
           "ext": {
-            "client": "prebid_server_0.5"
+            "client": "prebid_server_0.6"
           }
         }
       },

--- a/adapters/smaato/smaatotest/supplemental/outdated-expires-header-response.json
+++ b/adapters/smaato/smaatotest/supplemental/outdated-expires-header-response.json
@@ -125,7 +125,7 @@
             "keywords": "power tools"
           },
           "ext": {
-            "client": "prebid_server_0.5"
+            "client": "prebid_server_0.6"
           }
         }
       },

--- a/adapters/smaato/smaatotest/video/multiple-adpods-skadn.json
+++ b/adapters/smaato/smaatotest/video/multiple-adpods-skadn.json
@@ -28,6 +28,19 @@
                     "bidder": {
                         "publisherId": "1100042525",
                         "adbreakId": "400000001"
+                    },
+                    "skadn": {
+                        "versions": ["2.0", "2.1", "2.2", "3.0", "4.0"],
+                        "sourceapp": "880047117",
+                        "productpage": 1,
+                        "skadnetlist": {
+                          "max": 306,
+                          "excl": [2, 8, 10, 55],
+                          "addl": [
+                            "cdkw7geqsh.skadnetwork",
+                            "qyJfv329m4.skadnetwork"
+                          ]
+                        }
                     }
                 }
             },
@@ -57,6 +70,19 @@
                     "bidder": {
                         "publisherId": "1100042525",
                         "adbreakId": "400000001"
+                    },
+                    "skadn": {
+                        "versions": ["2.0", "2.1", "2.2", "3.0", "4.0"],
+                        "sourceapp": "880047118",
+                        "productpage": 1,
+                        "skadnetlist": {
+                          "max": 306,
+                          "excl": [2, 8, 10, 55],
+                          "addl": [
+                            "cdkw7geqsh.skadnetwork",
+                            "qyJfv329m4.skadnetwork"
+                          ]
+                        }
                     }
                 }
             },
@@ -86,6 +112,19 @@
                     "bidder": {
                         "publisherId": "1100042525",
                         "adbreakId": "400000001"
+                    },
+                    "skadn": {
+                        "versions": ["2.0", "2.1", "2.2", "3.0", "4.0"],
+                        "sourceapp": "880047119",
+                        "productpage": 1,
+                        "skadnetlist": {
+                          "max": 306,
+                          "excl": [2, 8, 10, 55],
+                          "addl": [
+                            "cdkw7geqsh.skadnetwork",
+                            "qyJfv329m4.skadnetwork"
+                          ]
+                        }
                     }
                 }
             },
@@ -115,6 +154,19 @@
                     "bidder": {
                         "publisherId": "1100042525",
                         "adbreakId": "400000001"
+                    },
+                    "skadn": {
+                        "versions": ["2.0", "2.1", "2.2", "3.0", "4.0"],
+                        "sourceapp": "880047120",
+                        "productpage": 1,
+                        "skadnetlist": {
+                          "max": 306,
+                          "excl": [2, 8, 10, 55],
+                          "addl": [
+                            "cdkw7geqsh.skadnetwork",
+                            "qyJfv329m4.skadnetwork"
+                          ]
+                        }
                     }
                 }
             }
@@ -181,6 +233,21 @@
                                 "sequence": 1,
                                 "ext": {
                                     "context": "adpod"
+                                }
+                            },
+                            "ext": {
+                                "skadn": {
+                                    "versions": ["2.0", "2.1", "2.2", "3.0", "4.0"],
+                                    "sourceapp": "880047117",
+                                    "productpage": 1,
+                                    "skadnetlist": {
+                                      "max": 306,
+                                      "excl": [2, 8, 10, 55],
+                                      "addl": [
+                                        "cdkw7geqsh.skadnetwork",
+                                        "qyJfv329m4.skadnetwork"
+                                      ]
+                                    }
                                 }
                             }
                         },
@@ -263,7 +330,29 @@
                                     "h": 768,
                                     "cat": ["IAB1"],
                                     "ext": {
-                                        "duration": 5
+                                        "duration": 5,
+                                        "skadn": {
+                                            "version": "2.2",
+                                            "network": "cdkw7geqsh.skadnetwork",
+                                            "campaign": "45",
+                                            "itunesitem": "123456789",
+                                            "sourceapp": "880047117",
+                                            "productpageid": "45812c9b-c296-43d3-c6a0-c5a02f74bf6e",
+                                            "fidelities": [
+                                              {
+                                                "fidelity": 0,
+                                                "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
+                                                "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
+                                                "timestamp": "1594406341"
+                                              },
+                                              {
+                                                "fidelity": 1,
+                                                "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
+                                                "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
+                                                "timestamp": "1594406342"
+                                              }
+                                            ]
+                                        }
                                     }
                                 },
                                 {
@@ -283,7 +372,29 @@
                                     "h": 768,
                                     "cat": ["IAB2"],
                                     "ext": {
-                                        "duration": 30
+                                        "duration": 30,
+                                        "skadn": {
+                                            "version": "2.2",
+                                            "network": "qyJfv329m4.skadnetwork",
+                                            "campaign": "45",
+                                            "itunesitem": "123456789",
+                                            "sourceapp": "880047117",
+                                            "productpageid": "45812c9b-c296-43d3-c6a0-c5a02f74bf6e",
+                                            "fidelities": [
+                                              {
+                                                "fidelity": 0,
+                                                "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
+                                                "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
+                                                "timestamp": "1594406341"
+                                              },
+                                              {
+                                                "fidelity": 1,
+                                                "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
+                                                "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
+                                                "timestamp": "1594406342"
+                                              }
+                                            ]
+                                        }
                                     }
                                 }
                             ]
@@ -333,6 +444,21 @@
                                 "sequence": 1,
                                 "ext": {
                                     "context": "adpod"
+                                }
+                            },
+                            "ext": {
+                                "skadn": {
+                                    "versions": ["2.0", "2.1", "2.2", "3.0", "4.0"],
+                                    "sourceapp": "880047119",
+                                    "productpage": 1,
+                                    "skadnetlist": {
+                                      "max": 306,
+                                      "excl": [2, 8, 10, 55],
+                                      "addl": [
+                                        "cdkw7geqsh.skadnetwork",
+                                        "qyJfv329m4.skadnetwork"
+                                      ]
+                                    }
                                 }
                             }
                         },
@@ -415,7 +541,29 @@
                                     "h": 768,
                                     "cat": ["IAB1"],
                                     "ext": {
-                                        "duration": 5
+                                        "duration": 5,
+                                        "skadn": {
+                                            "version": "2.2",
+                                            "network": "cdkw7geqsh.skadnetwork",
+                                            "campaign": "45",
+                                            "itunesitem": "123456789",
+                                            "sourceapp": "880047119",
+                                            "productpageid": "45812c9b-c296-43d3-c6a0-c5a02f74bf6e",
+                                            "fidelities": [
+                                              {
+                                                "fidelity": 0,
+                                                "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
+                                                "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
+                                                "timestamp": "1594406341"
+                                              },
+                                              {
+                                                "fidelity": 1,
+                                                "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
+                                                "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
+                                                "timestamp": "1594406342"
+                                              }
+                                            ]
+                                        }
                                     }
                                 },
                                 {
@@ -435,7 +583,29 @@
                                     "h": 768,
                                     "cat": ["IAB2"],
                                     "ext": {
-                                        "duration": 30
+                                        "duration": 30,
+                                        "skadn": {
+                                            "version": "2.2",
+                                            "network": "qyJfv329m4.skadnetwork",
+                                            "campaign": "45",
+                                            "itunesitem": "123456789",
+                                            "sourceapp": "880047119",
+                                            "productpageid": "45812c9b-c296-43d3-c6a0-c5a02f74bf6e",
+                                            "fidelities": [
+                                              {
+                                                "fidelity": 0,
+                                                "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
+                                                "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
+                                                "timestamp": "1594406341"
+                                              },
+                                              {
+                                                "fidelity": 1,
+                                                "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
+                                                "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
+                                                "timestamp": "1594406342"
+                                              }
+                                            ]
+                                        }
                                     }
                                 }
                             ]
@@ -468,7 +638,29 @@
                         "h": 768,
                         "cat": ["IAB1"],
                         "ext": {
-                            "duration": 5
+                            "duration": 5,
+                            "skadn": {
+                                "version": "2.2",
+                                "network": "cdkw7geqsh.skadnetwork",
+                                "campaign": "45",
+                                "itunesitem": "123456789",
+                                "sourceapp": "880047117",
+                                "productpageid": "45812c9b-c296-43d3-c6a0-c5a02f74bf6e",
+                                "fidelities": [
+                                  {
+                                    "fidelity": 0,
+                                    "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
+                                    "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
+                                    "timestamp": "1594406341"
+                                  },
+                                  {
+                                    "fidelity": 1,
+                                    "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
+                                    "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
+                                    "timestamp": "1594406342"
+                                  }
+                                ]
+                            }
                         },
                         "exp": 300
                     },
@@ -492,7 +684,29 @@
                         "h": 768,
                         "cat": ["IAB2"],
                         "ext": {
-                            "duration": 30
+                            "duration": 30,
+                            "skadn": {
+                                "version": "2.2",
+                                "network": "qyJfv329m4.skadnetwork",
+                                "campaign": "45",
+                                "itunesitem": "123456789",
+                                "sourceapp": "880047117",
+                                "productpageid": "45812c9b-c296-43d3-c6a0-c5a02f74bf6e",
+                                "fidelities": [
+                                  {
+                                    "fidelity": 0,
+                                    "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
+                                    "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
+                                    "timestamp": "1594406341"
+                                  },
+                                  {
+                                    "fidelity": 1,
+                                    "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
+                                    "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
+                                    "timestamp": "1594406342"
+                                  }
+                                ]
+                            }
                         },
                         "exp": 300
                     },
@@ -520,7 +734,29 @@
                         "h": 768,
                         "cat": ["IAB1"],
                         "ext": {
-                            "duration": 5
+                            "duration": 5,
+                            "skadn": {
+                                "version": "2.2",
+                                "network": "cdkw7geqsh.skadnetwork",
+                                "campaign": "45",
+                                "itunesitem": "123456789",
+                                "sourceapp": "880047119",
+                                "productpageid": "45812c9b-c296-43d3-c6a0-c5a02f74bf6e",
+                                "fidelities": [
+                                  {
+                                    "fidelity": 0,
+                                    "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
+                                    "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
+                                    "timestamp": "1594406341"
+                                  },
+                                  {
+                                    "fidelity": 1,
+                                    "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
+                                    "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
+                                    "timestamp": "1594406342"
+                                  }
+                                ]
+                            }
                         },
                         "exp": 300
                     },
@@ -543,7 +779,29 @@
                         "h": 768,
                         "cat": ["IAB2"],
                         "ext": {
-                            "duration": 30
+                            "duration": 30,
+                            "skadn": {
+                                "version": "2.2",
+                                "network": "qyJfv329m4.skadnetwork",
+                                "campaign": "45",
+                                "itunesitem": "123456789",
+                                "sourceapp": "880047119",
+                                "productpageid": "45812c9b-c296-43d3-c6a0-c5a02f74bf6e",
+                                "fidelities": [
+                                  {
+                                    "fidelity": 0,
+                                    "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
+                                    "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
+                                    "timestamp": "1594406341"
+                                  },
+                                  {
+                                    "fidelity": 1,
+                                    "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
+                                    "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
+                                    "timestamp": "1594406342"
+                                  }
+                                ]
+                            }
                         },
                         "exp": 300
                     },

--- a/adapters/smaato/smaatotest/video/single-adpod-skadn.json
+++ b/adapters/smaato/smaatotest/video/single-adpod-skadn.json
@@ -24,10 +24,24 @@
                         7
                     ]
                 },
+                "bidfloor": 0.00123,
                 "ext": {
                     "bidder": {
                         "publisherId": "1100042525",
                         "adbreakId": "400000001"
+                    },
+                    "skadn": {
+                        "versions": ["2.0", "2.1", "2.2", "3.0", "4.0"],
+                        "sourceapp": "880047117",
+                        "productpage": 1,
+                        "skadnetlist": {
+                          "max": 306,
+                          "excl": [2, 8, 10, 55],
+                          "addl": [
+                            "cdkw7geqsh.skadnetwork",
+                            "qyJfv329m4.skadnetwork"
+                          ]
+                        }
                     }
                 }
             },
@@ -53,68 +67,24 @@
                         7
                     ]
                 },
+                "bidfloor": 0.00123,
                 "ext": {
                     "bidder": {
                         "publisherId": "1100042525",
                         "adbreakId": "400000001"
-                    }
-                }
-            },
-            {
-                "id": "2_1",
-                "video": {
-                    "mimes": [
-                        "video/mp4",
-                        "video/3gpp"
-                    ],
-                    "minduration": 5,
-                    "maxduration": 30,
-                    "protocols": [
-                        7
-                    ],
-                    "w": 1024,
-                    "h": 768,
-                    "startdelay": 0,
-                    "linearity": 1,
-                    "skip": 1,
-                    "skipmin": 5,
-                    "api": [
-                        7
-                    ]
-                },
-                "ext": {
-                    "bidder": {
-                        "publisherId": "1100042525",
-                        "adbreakId": "400000001"
-                    }
-                }
-            },
-            {
-                "id": "2_2",
-                "video": {
-                    "mimes": [
-                        "video/mp4",
-                        "video/3gpp"
-                    ],
-                    "minduration": 5,
-                    "maxduration": 30,
-                    "protocols": [
-                        7
-                    ],
-                    "w": 1024,
-                    "h": 768,
-                    "startdelay": 0,
-                    "linearity": 1,
-                    "skip": 1,
-                    "skipmin": 5,
-                    "api": [
-                        7
-                    ]
-                },
-                "ext": {
-                    "bidder": {
-                        "publisherId": "1100042525",
-                        "adbreakId": "400000001"
+                    },
+                    "skadn": {
+                        "versions": ["2.0", "2.1", "2.2", "3.0", "4.0"],
+                        "sourceapp": "880047118",
+                        "productpage": 1,
+                        "skadnetlist": {
+                          "max": 306,
+                          "excl": [2, 8, 10, 55],
+                          "addl": [
+                            "cdkw7geqsh.skadnetwork",
+                            "qyJfv329m4.skadnetwork"
+                          ]
+                        }
                     }
                 }
             }
@@ -159,6 +129,7 @@
                         {
                             "id": "1_1",
                             "tagid": "400000001",
+                            "bidfloor": 0.00123,
                             "video": {
                                 "w": 1024,
                                 "h": 768,
@@ -182,11 +153,27 @@
                                 "ext": {
                                     "context": "adpod"
                                 }
+                            },
+                            "ext": {
+                                "skadn": {
+                                    "versions": ["2.0", "2.1", "2.2", "3.0", "4.0"],
+                                    "sourceapp": "880047117",
+                                    "productpage": 1,
+                                    "skadnetlist": {
+                                      "max": 306,
+                                      "excl": [2, 8, 10, 55],
+                                      "addl": [
+                                        "cdkw7geqsh.skadnetwork",
+                                        "qyJfv329m4.skadnetwork"
+                                      ]
+                                    }
+                                }
                             }
                         },
                         {
                             "id": "1_2",
                             "tagid": "400000001",
+                            "bidfloor": 0.00123,
                             "video": {
                                 "w": 1024,
                                 "h": 768,
@@ -263,7 +250,29 @@
                                     "h": 768,
                                     "cat": ["IAB1"],
                                     "ext": {
-                                        "duration": 5
+                                        "duration": 5,
+                                        "skadn": {
+                                            "version": "2.2",
+                                            "network": "cdkw7geqsh.skadnetwork",
+                                            "campaign": "45",
+                                            "itunesitem": "123456789",
+                                            "sourceapp": "880047117",
+                                            "productpageid": "45812c9b-c296-43d3-c6a0-c5a02f74bf6e",
+                                            "fidelities": [
+                                              {
+                                                "fidelity": 0,
+                                                "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
+                                                "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
+                                                "timestamp": "1594406341"
+                                              },
+                                              {
+                                                "fidelity": 1,
+                                                "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
+                                                "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
+                                                "timestamp": "1594406342"
+                                              }
+                                            ]
+                                        }
                                     }
                                 },
                                 {
@@ -283,159 +292,29 @@
                                     "h": 768,
                                     "cat": ["IAB2"],
                                     "ext": {
-                                        "duration": 30
-                                    }
-                                }
-                            ]
-                        }
-                    ],
-                    "bidid": "04db8629-179d-4bcd-acce-e54722969006",
-                    "cur": "USD"
-                }
-            }
-        },
-        {
-            "expectedRequest": {
-                "headers": {
-                    "Content-Type": [
-                        "application/json;charset=utf-8"
-                    ],
-                    "Accept": [
-                        "application/json"
-                    ]
-                },
-                "uri": "https://prebid/bidder",
-                "body": {
-                    "id": "447a0a1d-389d-4730-a418-3777e95de7bd",
-                    "imp": [
-                        {
-                            "id": "2_1",
-                            "tagid": "400000001",
-                            "video": {
-                                "w": 1024,
-                                "h": 768,
-                                "mimes": [
-                                    "video/mp4",
-                                    "video/3gpp"
-                                ],
-                                "minduration": 5,
-                                "startdelay": 0,
-                                "linearity": 1,
-                                "maxduration": 30,
-                                "skip": 1,
-                                "protocols": [
-                                    7
-                                ],
-                                "skipmin": 5,
-                                "api": [
-                                    7
-                                ],
-                                "sequence": 1,
-                                "ext": {
-                                    "context": "adpod"
-                                }
-                            }
-                        },
-                        {
-                            "id": "2_2",
-                            "tagid": "400000001",
-                            "video": {
-                                "w": 1024,
-                                "h": 768,
-                                "mimes": [
-                                    "video/mp4",
-                                    "video/3gpp"
-                                ],
-                                "minduration": 5,
-                                "startdelay": 0,
-                                "linearity": 1,
-                                "maxduration": 30,
-                                "skip": 1,
-                                "protocols": [
-                                    7
-                                ],
-                                "skipmin": 5,
-                                "api": [
-                                    7
-                                ],
-                                "sequence": 2,
-                                "ext": {
-                                    "context": "adpod"
-                                }
-                            }
-                        }
-                    ],
-                    "user": {
-                        "ext": {
-                        }
-                    },
-                    "device": {
-                        "ua": "test-user-agent"
-                    },
-                    "site": {
-                        "publisher": {
-                            "id": "1100042525"
-                        },
-                        "content": {
-                            "title": "a-title",
-                            "season": "a-season",
-                            "series": "a-series",
-                            "episode": 1,
-                            "len": 900,
-                            "livestream": 1
-                        }
-                    },
-                    "ext": {
-                        "client": "prebid_server_0.6"
-                    }
-                }
-            },
-            "mockResponse": {
-                "status": 200,
-                "body": {
-                    "id": "5ebea288-f13a-4754-be6d-4ade66c68877",
-                    "seatbid": [
-                        {
-                            "seat": "CM6523",
-                            "bid": [
-                                {
-                                    "adm": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><VAST version=\"2.0\"></VAST>",
-                                    "adomain": [
-                                        "smaato.com"
-                                    ],
-                                    "bidderName": "smaato",
-                                    "cid": "CM6523",
-                                    "crid": "CR69381",
-                                    "id": "6906aae8-7f74-4edd-9a4f-f49379a3cadd",
-                                    "impid": "2_1",
-                                    "iurl": "https://iurl",
-                                    "nurl": "https://nurl",
-                                    "price": 0.01,
-                                    "w": 1024,
-                                    "h": 768,
-                                    "cat": ["IAB1"],
-                                    "ext": {
-                                        "duration": 5
-                                    }
-                                },
-                                {
-                                    "adm": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><VAST version=\"2.0\"></VAST>",
-                                    "adomain": [
-                                        "smaato.com"
-                                    ],
-                                    "bidderName": "smaato",
-                                    "cid": "CM6523",
-                                    "crid": "CR69381",
-                                    "id": "6906aae8-7f74-4edd-9a4f-f49379a3cadd",
-                                    "impid": "2_2",
-                                    "iurl": "https://iurl",
-                                    "nurl": "https://nurl",
-                                    "price": 0.01,
-                                    "w": 1024,
-                                    "h": 768,
-                                    "cat": ["IAB2"],
-                                    "ext": {
-                                        "duration": 30
+                                        "duration": 30,
+                                        "skadn": {
+                                            "version": "2.2",
+                                            "network": "qyJfv329m4.skadnetwork",
+                                            "campaign": "45",
+                                            "itunesitem": "123456789",
+                                            "sourceapp": "880047117",
+                                            "productpageid": "45812c9b-c296-43d3-c6a0-c5a02f74bf6e",
+                                            "fidelities": [
+                                              {
+                                                "fidelity": 0,
+                                                "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
+                                                "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
+                                                "timestamp": "1594406341"
+                                              },
+                                              {
+                                                "fidelity": 1,
+                                                "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
+                                                "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
+                                                "timestamp": "1594406342"
+                                              }
+                                            ]
+                                        }
                                     }
                                 }
                             ]
@@ -468,12 +347,33 @@
                         "h": 768,
                         "cat": ["IAB1"],
                         "ext": {
-                            "duration": 5
+                            "duration": 5,
+                            "skadn": {
+                                "version": "2.2",
+                                "network": "cdkw7geqsh.skadnetwork",
+                                "campaign": "45",
+                                "itunesitem": "123456789",
+                                "sourceapp": "880047117",
+                                "productpageid": "45812c9b-c296-43d3-c6a0-c5a02f74bf6e",
+                                "fidelities": [
+                                  {
+                                    "fidelity": 0,
+                                    "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
+                                    "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
+                                    "timestamp": "1594406341"
+                                  },
+                                  {
+                                    "fidelity": 1,
+                                    "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
+                                    "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
+                                    "timestamp": "1594406342"
+                                  }
+                                ]
+                            }
                         },
                         "exp": 300
                     },
                     "type": "video"
-
                 },
                 {
                     "bid": {
@@ -492,58 +392,29 @@
                         "h": 768,
                         "cat": ["IAB2"],
                         "ext": {
-                            "duration": 30
-                        },
-                        "exp": 300
-                    },
-                    "type": "video"
-                }
-            ]
-        },
-        {
-            "currency": "USD",
-            "bids": [
-                {
-                    "bid": {
-                        "adm": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><VAST version=\"2.0\"></VAST>",
-                        "adomain": [
-                            "smaato.com"
-                        ],
-                        "cid": "CM6523",
-                        "crid": "CR69381",
-                        "id": "6906aae8-7f74-4edd-9a4f-f49379a3cadd",
-                        "impid": "2_1",
-                        "iurl": "https://iurl",
-                        "nurl": "https://nurl",
-                        "price": 0.01,
-                        "w": 1024,
-                        "h": 768,
-                        "cat": ["IAB1"],
-                        "ext": {
-                            "duration": 5
-                        },
-                        "exp": 300
-                    },
-                    "type": "video"
-                },
-                {
-                    "bid": {
-                        "adm": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><VAST version=\"2.0\"></VAST>",
-                        "adomain": [
-                            "smaato.com"
-                        ],
-                        "cid": "CM6523",
-                        "crid": "CR69381",
-                        "id": "6906aae8-7f74-4edd-9a4f-f49379a3cadd",
-                        "impid": "2_2",
-                        "iurl": "https://iurl",
-                        "nurl": "https://nurl",
-                        "price": 0.01,
-                        "w": 1024,
-                        "h": 768,
-                        "cat": ["IAB2"],
-                        "ext": {
-                            "duration": 30
+                            "duration": 30,
+                            "skadn": {
+                                "version": "2.2",
+                                "network": "qyJfv329m4.skadnetwork",
+                                "campaign": "45",
+                                "itunesitem": "123456789",
+                                "sourceapp": "880047117",
+                                "productpageid": "45812c9b-c296-43d3-c6a0-c5a02f74bf6e",
+                                "fidelities": [
+                                  {
+                                    "fidelity": 0,
+                                    "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
+                                    "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
+                                    "timestamp": "1594406341"
+                                  },
+                                  {
+                                    "fidelity": 1,
+                                    "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
+                                    "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
+                                    "timestamp": "1594406342"
+                                  }
+                                ]
+                            }
                         },
                         "exp": 300
                     },

--- a/adapters/smaato/smaatotest/video/single-adpod.json
+++ b/adapters/smaato/smaatotest/video/single-adpod.json
@@ -180,7 +180,7 @@
                         }
                     },
                     "ext": {
-                        "client": "prebid_server_0.5"
+                        "client": "prebid_server_0.6"
                     }
                 }
             },

--- a/adapters/smaato/smaatotest/videosupplemental/bad-adm-response.json
+++ b/adapters/smaato/smaatotest/videosupplemental/bad-adm-response.json
@@ -176,7 +176,7 @@
             }
           },
           "ext": {
-            "client": "prebid_server_0.5"
+            "client": "prebid_server_0.6"
           }
         }
       },

--- a/adapters/smaato/smaatotest/videosupplemental/bad-bid-ext-response.json
+++ b/adapters/smaato/smaatotest/videosupplemental/bad-bid-ext-response.json
@@ -176,7 +176,7 @@
             }
           },
           "ext": {
-            "client": "prebid_server_0.5"
+            "client": "prebid_server_0.6"
           }
         }
       },

--- a/adapters/smaato/smaatotest/videosupplemental/bad-skadn-format-request.json
+++ b/adapters/smaato/smaatotest/videosupplemental/bad-skadn-format-request.json
@@ -1,0 +1,89 @@
+{
+    "mockBidRequest": {
+        "id": "447a0a1d-389d-4730-a418-3777e95de7bd",
+        "imp": [
+            {
+                "id": "1_1",
+                "video": {
+                    "mimes": [
+                        "video/mp4",
+                        "video/3gpp"
+                    ],
+                    "minduration": 5,
+                    "maxduration": 30,
+                    "protocols": [
+                        7
+                    ],
+                    "w": 1024,
+                    "h": 768,
+                    "startdelay": 0,
+                    "linearity": 1,
+                    "skip": 1,
+                    "skipmin": 5,
+                    "api": [
+                        7
+                    ]
+                },
+                "bidfloor": 0.00123,
+                "ext": {
+                    "bidder": {
+                        "publisherId": "1100042525",
+                        "adbreakId": "400000001"
+                    },
+                    "skadn": []
+                }
+            },
+            {
+                "id": "1_2",
+                "video": {
+                    "mimes": [
+                        "video/mp4",
+                        "video/3gpp"
+                    ],
+                    "minduration": 5,
+                    "maxduration": 30,
+                    "protocols": [
+                        7
+                    ],
+                    "w": 1024,
+                    "h": 768,
+                    "startdelay": 0,
+                    "linearity": 1,
+                    "skip": 1,
+                    "skipmin": 5,
+                    "api": [
+                        7
+                    ]
+                },
+                "bidfloor": 0.00123
+            }
+        ],
+        "site": {
+            "publisher": {
+                "id": "1100042525"
+            },
+            "content": {
+                "title": "a-title",
+                "season": "a-season",
+                "series": "a-series",
+                "episode": 1,
+                "len": 900,
+                "livestream": 1
+            }
+        },
+        "device": {
+            "ua": "test-user-agent"
+        },
+        "user": {
+            "ext": {
+                "data": {}
+            }
+        }
+    },
+    "expectedMakeRequestsErrors": [
+        {
+          "value": "Invalid imp.ext.skadn.",
+          "comparison": "literal"
+        }
+    ]
+}


### PR DESCRIPTION
The implementation should be straightforward. There is the request.imp[].ext.bidder and request.imp[].ext.skadn. And we copy only the skadn part to impExt, without the bidder params. at https://github.com/smaato/prebid-server/blob/b9f7bab1394593814f61fcf31fb159caedaac069/adapters/smaato/smaato.go#L530

Then the next condition is optional, as the underlying code already checks for JSON errors. at https://github.com/smaato/prebid-server/blob/b9f7bab1394593814f61fcf31fb159caedaac069/adapters/smaato/smaato.go#L534-L540

Then we convert back to JSON, this time only having our impExtData object, containing skadn, and send null if an empty object is created. This is to prevent sending an empty "skadn": {} object to SOMA (performance & resources). at https://github.com/smaato/prebid-server/blob/b9f7bab1394593814f61fcf31fb159caedaac069/adapters/smaato/smaato.go#L542-L546


As for the bid response, there were no changes. Our SOMA sends the response exactly as required, and skadn is working correctly (field ext present in OpenRTB bid as json.RawMessage).


Most of the tests were copied and I added skadn fields everywhere (the skadn example is also copied from the example provided by the prebid team), changing the 'sourceapp' in different locations to make sure that the correct req/resp and imps are having the correct values.